### PR TITLE
Fix env name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or
 
 ```bash
 conda env create -f environment.yml
-conda activate project
+conda activate unconference
 ```
 
 Then, run


### PR DESCRIPTION
The current env name in the README is [project](https://github.com/numfocus/disc-unconference-2025-projects/blame/a36534b8586a774e9aaf236f9b5e5a895696d357/README.md#L31), but it should be [unconference](https://github.com/numfocus/disc-unconference-2025-projects/blob/a36534b8586a774e9aaf236f9b5e5a895696d357/environment.yml#L1).